### PR TITLE
Reduce system load from vpdupdate udev rule

### DIFF
--- a/90-vpdupdate.rules
+++ b/90-vpdupdate.rules
@@ -19,6 +19,18 @@ DEVPATH=="/devices/uprobe/*", GOTO="vpd_end"
 DEVPATH=="/devices/kprobe/*", GOTO="vpd_end"
 DEVPATH=="/devices/rbd/*", GOTO="vpd_end"
 
+SUBSYSTEM=="scsi_device", GOTO="vpd_update"
+SUBSYSTEM=="scsi_host", GOTO="vpd_update"
+# Don't generate extra events, we have one for the scsi_device already
+# This rule also skips SCSI block device uevents
+# (but the corresponding scsi_device will have triggered vpdupdate).
+SUBSYSTEMS=="scsi*", GOTO="vpd_end"
+
+# virtual NVMe devices (NVMeoF) are skipped because of the rule above
+SUBSYSTEM=="nvme", GOTO="vpd_update"
+SUBSYSTEM=="nvme-subsystem", GOTO="vpd_update"
+SUBSYSTEMS=="nvme*", GOTO="vpd_end"
+
 LABEL="vpd_update"
 RUN+="/bin/touch /run/run.vpdupdate"
 LABEL="vpd_end"

--- a/90-vpdupdate.rules
+++ b/90-vpdupdate.rules
@@ -1,1 +1,19 @@
-KERNELS=="*", ACTION=="*", DEVPATH=="/devices/*", RUN+="/bin/touch /run/run.vpdupdate"
+DEVPATH!="/devices/*", GOTO="vpd_end"
+# See SysFSTreeCollector::filterDevicePath()
+DEVPATH=="/devices/virtual/*", GOTO="vpd_end"
+DEVPATH=="/devices/system/*", GOTO="vpd_end"
+DEVPATH=="/devices/cpu/*", GOTO="vpd_end"
+DEVPATH=="/devices/breakpoint/*", GOTO="vpd_end"
+DEVPATH=="/devices/tracepoint/*", GOTO="vpd_end"
+DEVPATH=="/devices/software/*", GOTO="vpd_end"
+
+# See SysFSTreeCollector::filterDevice()
+ENV{DEVTYPE}=="scsi_target", GOTO="vpd_end"
+SUBSYSTEM=="enclosure", GOTO="vpd_end"
+
+# See SysFSTreeCollector::isDevice()
+ENV{DEVTYPE}=="partition", GOTO="vpd_end"
+
+LABEL="vpd_update"
+RUN+="/bin/touch /run/run.vpdupdate"
+LABEL="vpd_end"

--- a/90-vpdupdate.rules
+++ b/90-vpdupdate.rules
@@ -14,6 +14,11 @@ SUBSYSTEM=="enclosure", GOTO="vpd_end"
 # See SysFSTreeCollector::isDevice()
 ENV{DEVTYPE}=="partition", GOTO="vpd_end"
 
+# More devices that aren't covered by VPD
+DEVPATH=="/devices/uprobe/*", GOTO="vpd_end"
+DEVPATH=="/devices/kprobe/*", GOTO="vpd_end"
+DEVPATH=="/devices/rbd/*", GOTO="vpd_end"
+
 LABEL="vpd_update"
 RUN+="/bin/touch /run/run.vpdupdate"
 LABEL="vpd_end"


### PR DESCRIPTION
The udev rule in `90-vpdupdate.rules` is extremely broad in scope, causing `touch /run/run.vpdupdate` to be forked and executed for __every uevent generated__. Apart from being superfluous, this can cause serious resource issues during boot, especially during "coldplug" on large power systems with thousands of CPUs and memory devices, and possibly similar numbers of storage devices. The typical user-visible signs of this are extremely long boot times on the order of several hours, and non-responsiveness of the system during boot. While debugging this, we've identified the `touch` processes started by the vpdupdate rule as a major slow-down factor.

Looking at the vpdupdate code, I found that vpdupdate actually skips a number of devices already. Therefore it's not useful to generate uevents for those. Besides that, I added some more device nodes I which (I believe) can be safely ignored, and modified the rules for SCSI such that "touch" is only called once for a new SCSI device, rather than 6 times.

I wasn't sure whether `ACTION=="change"` events could also be skipped (I don't think it so, but it might if e.g. the size of a SCSI device changes - I don't see this sort of property in the VPD data base, but I may be overlooking something). For the time being, I haven't added a rule skipping "change" events.

(Side note: vpdupdate should really be rewritten to use `udev_enumerate_scan_devices` rather than its own hand-crafted sysfs scanning code. But that's a different issue).