### PR TITLE
Remove dynamic exception specification

### DIFF
--- a/src/libvpd-2/vpdretriever.hpp
+++ b/src/libvpd-2/vpdretriever.hpp
@@ -58,8 +58,7 @@ namespace lsvpd
 			 * @param dbFileName
 			 *   The file name for the VPD database.
 			 */
-			VpdRetriever( string envDir, string dbFileName )
-				throw( VpdException& );
+			VpdRetriever( string envDir, string dbFileName );
 			
 			/**
 			 * Builds A VpdRetriever object that can be used for reading the
@@ -70,8 +69,7 @@ namespace lsvpd
 			 * this constructor, there were serious underlying issues that
 			 * are not recoverable.  Uses the default dir and filename
 			 */
-			VpdRetriever( )
-				throw( VpdException& );
+			VpdRetriever( );
 			~VpdRetriever( );
 
 			/**

--- a/src/vpdretriever.cpp
+++ b/src/vpdretriever.cpp
@@ -47,7 +47,7 @@ namespace lsvpd
 	const string VpdRetriever::UDEV_NOTIFY_FILE ( "/run/run.vpdupdate" );
 
 	VpdRetriever::VpdRetriever( string envDir,
-		string dbFileName ) throw( VpdException& )
+		string dbFileName )
 	{
 		try {
 			db = new VpdDbEnv( envDir, dbFileName, true );
@@ -59,7 +59,7 @@ namespace lsvpd
 		}
 	}
 	
-	VpdRetriever::VpdRetriever( ) throw( VpdException& )
+	VpdRetriever::VpdRetriever( )
 	{
 		struct stat vpd_stat,udev_stat;
 		const string vpddb = VpdRetriever::DEFAULT_DIR + VpdRetriever::DEFAULT_FILE;


### PR DESCRIPTION
Tomasz Kłoczko reported that the build fails, while compiling
with GCC 11:

In file included from src/vpdretriever.cpp:25:
./src/libvpd-2/vpdretriever.hpp:62:33: error: ISO C++17 does not allow dynamic exception specifications
   62 |                                 throw( VpdException& );
      |                                 ^~~~~
./src/libvpd-2/vpdretriever.hpp:74:33: error: ISO C++17 does not allow dynamic exception specifications
   74 |                                 throw( VpdException& );
      |                                 ^~~~~
src/vpdretriever.cpp:50:37: error: ISO C++17 does not allow dynamic exception specifications
   50 |                 string dbFileName ) throw( VpdException& )
      |                                     ^~~~~
src/vpdretriever.cpp:62:39: error: ISO C++17 does not allow dynamic exception specifications
   62 |         VpdRetriever::VpdRetriever( ) throw( VpdException& )
      |                                       ^~~~~
make: *** [Makefile:660: src/vpdretriever.lo] Error 1

As part of
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0003r5.html,
the dynamic exception specification have been removed. Remove the
throw specifier, to specify that the function might throw an exception.

Fixes: #4
Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>