### PR TITLE
vpddbenv_c: fix compile warnings

### DIFF
--- a/src/vpddbenv_c.c
+++ b/src/vpddbenv_c.c
@@ -53,9 +53,9 @@ struct vpddbenv * new_vpddbenv( const char *dir, const char *file )
 	strncpy( ret->fullPath, ret->envDir , FULL_PATH_SIZE - 1);
 
 	if (strlen(ret->fullPath) + 1 < FULL_PATH_SIZE)
-		strncat( ret->fullPath, "/" , 1 );
+		strcat( ret->fullPath, "/" );
 	if (strlen(ret->fullPath) + strlen(ret->dbFileName) < FULL_PATH_SIZE)
-		strncat( ret->fullPath, ret->dbFileName, strlen (ret->dbFileName) );
+		strcat( ret->fullPath, ret->dbFileName );
 
 	ret->fullPath[FULL_PATH_SIZE - 1] = '\0';
 	


### PR DESCRIPTION
src/vpddbenv_c.c: In function 'new_vpddbenv':
src/vpddbenv_c.c:56:17: warning: 'strncat' specified bound 1 equals source length [-Wstringop-overflow=]
   56 |                 strncat( ret->fullPath, "/" , 1 );
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/vpddbenv_c.c:58:17: warning: 'strncat' accessing between 258 and 9223372036854775804 bytes at offsets 514 and 257 may overlap 1 byte at offset 514 [-Wrestrict]
   58 |                 strncat( ret->fullPath, ret->dbFileName, strlen(ret->dbFileName) );
      |
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

While compiling the code with GCC-11 (Fedora 34), the GCC complains
about src string length and N bytes mentioned in the strncat() are of
same length. It gets suspicious, when strncat() mimics strcat(), the
strcat() was replaced using strncat() by the commit 38de4e65205
("libvpd: Convert strcat to strncat") as part of secure coding.

This patch silences the warning by partly reverting the commit by
replacing the strncat() with original strcat(), on the secure coding
there are conditional checks before strcat(), those prevent the string
from over-flow.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.ibm.com>